### PR TITLE
Don't use gradle files from npm #280

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,33 +1,18 @@
-import org.apache.tools.ant.taskdefs.condition.Os;
-
 plugins {
     id 'com.enonic.defaults' version '2.0.1'
-    id 'com.enonic.xp.app' version '3.1.0'
+    id 'com.enonic.xp.app' version '3.2.0'
     id "com.github.node-gradle.node" version "3.4.0"
-
-    //id 'org.barfuin.gradle.taskinfo' version '1.0.1' // ./gradlew tiTree deploy
+    id 'react4xp'
 }
 
 repositories {
-    // com.enonic.lib:lib-react4xp:x.x.x-SNAPSHOT
-    mavenLocal()
-
-    // com.enonic.lib:lib-cache
-    // com.enonic.lib:lib-guillotine
-    // com.enonic.lib:lib-thymeleaf
-    // com.enonic.xp:lib-content
-    // com.enonic.xp:lib-io
-    // com.enonic.xp:lib-portal
     xp.enonicRepo('dev')
-
-    // com.graphql-java
-    // jaxen:jaxen
-    // io.reactivex.rxjava2:rxjava
-    // org.apache.commons:commons-pool2
-    // org.jdom:jdom
-    // org.json:json
-    // org.thymeleaf:thymeleaf
     mavenCentral()
+}
+
+node {
+    download = true
+    version = '16.0.0'
 }
 
 app {
@@ -37,9 +22,6 @@ app {
     vendorUrl = "${vendorUrl}"
     systemVersion = "${xpVersion}"
 }
-
-// This variable is used in the include lib-react4xp below, and also used in the optional tasks in readme.gradle
-rootProject.ext.LIB_REACT4XP_VERSION = "3.2.2"
 
 dependencies {
     implementation "com.enonic.xp:core-api:${xpVersion}"
@@ -56,7 +38,7 @@ dependencies {
     include "com.enonic.lib:lib-thymeleaf:2.0.1"
     include "com.enonic.lib:lib-guillotine:5.5.0"
 
-    include "com.enonic.lib:lib-react4xp:${rootProject.ext.LIB_REACT4XP_VERSION}"
+    include "com.enonic.lib:lib-react4xp:3.2.2"
 }
 
 sourceSets {
@@ -70,7 +52,6 @@ sourceSets {
 }
 
 processResources {
-  // find src -type f ! -name "*.es6" -a ! -name "*.jsx" -a ! -name "*.gitkeep" -a ! -name "*.png" -a ! -name "*.svg" -a ! -name "*.xml"
   // Files that are simply copied by gradle: png svg xml
   exclude '**/.gitkeep'
   exclude '**/*.es6' // non-react ones handled by task compileXP
@@ -82,51 +63,6 @@ processResources {
 tasks.withType(Copy) {
   includeEmptyDirs = false
 }
-
-
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-// The react4xp NPM package also carries additional .gradle files that are required by this gradle setup (further below).
-// If they don't exist, run 'npm install' as a shell command (can't be done as a regular gradle task,
-// since they are needed in the gradle config phase).
-def react4xpGradlePath = 'node_modules/@enonic/react4xp/react4xp.gradle'
-def react4xpGradleFile = new File(react4xpGradlePath)
-if (!react4xpGradleFile.exists()) {
-    String npm = 'npm'
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        npm = 'npm.cmd'
-    }
-    def command = npm + " install"
-    println "\nNot found: $react4xpGradlePath - running shell command:"
-    println command
-    def proc = command.execute()
-    proc.in.eachLine { line -> println line }
-    proc.out.close()
-    proc.waitFor()
-}
-
-// Necessary react4xp build setup.
-// node_modules/@enonic/react4xp/react4xp.gradle (react4xpGradlePath) etc. are used by the gradle tasks, so 'npm install' should have been run automatically by now (above).
-apply from: react4xpGradlePath
-
-// Optional dev convenience:
-// Adjusts the regular 'npmInstall' gradle task with two improvements:
-//      - NSI allows npm-linked local development (https://www.npmjs.com/package/npm-safe-install)
-//      - faster gradle up-to-date check during build (only checks content of package.json and package-lock.json,
-//          and a marker file for whether node_module exists as a regular or NSI-linked version. Runs NSI if it's linked.
-//          Does not check the entire node_modules subtree).
-apply from: 'node_modules/@enonic/react4xp/npmInstall.gradle'
-
-// Optional dev convenience:
-// Adds the 'updateReadme' gradle task which generates readme files at root from docs/README.src.md
-apply from: 'node_modules/@enonic/react4xp/updaters.gradle'
-
-
-
-
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -157,20 +93,3 @@ task compileXP(type: NodeTask) {
 }
 compileXP.dependsOn += npmInstall
 jar.dependsOn += 'compileXP'
-
-
-task printSourceSetInformation(){
-    doLast{
-        sourceSets.each { srcSet ->
-            println "["+srcSet.name+"]"
-            print "-->Source directories: "+srcSet.allJava.srcDirs+"\n"
-            print "-->Resources directories: "+srcSet.resources.srcDirs+"\n"
-            print "-->Output directories: "+srcSet.output.classesDirs.files+"\n"
-            println "Resources"
-            srcSet.resources.files.each {
-                print "  "+it.path+"\n"
-            }
-            println ""
-        }
-    }
-}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}

--- a/buildSrc/src/main/groovy/react4xp.gradle
+++ b/buildSrc/src/main/groovy/react4xp.gradle
@@ -15,17 +15,9 @@ if (
   project.ext.react4xp.BUILD_ENV='development';
 }
 
-
-// Used in ./npmInstall.gradle
-if (project.hasProperty("link") || project.hasProperty("linked") || project.ext.react4xp.BUILD_ENV == "development") {
-  project.ext.react4xp.NPMLINKED = true
-}
-
-
 if (gradle.startParameter.logLevel == LogLevel.INFO) {
   project.ext.react4xp.VERBOSE = 'true';
 }
-
 
 task react4xpComponents(type: NpmTask) {
   group 'React4xp'
@@ -109,50 +101,5 @@ StartParameter startParameter = project.gradle.startParameter;
   task.doFirst {
     if (startParameter.isContinuous()) { throw new StopExecutionException() }
   }
-
-}
-
-// Adds optional dev convenience: adjusts the regular 'npmInstall' gradle task with two improvements:
-//      - NSI allows npm-linked local development (https://www.npmjs.com/package/npm-safe-install)
-//      - faster gradle up-to-date check during build (only checks content of package.json and package-lock.json,
-//          and a marker file for whether node_module exists as a regular or NSI-linked version. Runs NSI if it's linked.
-//          Does not check the entire node_modules subtree).
-
-
-// These are not supplied from react4xp, they are just names used for buildtime housekeeping:
-def markerName = "node_modules/@enonic/react4xp/npmInstalled.marker"
-
-if (project.ext.react4xp.NPMLINKED == true) {
-  task nsiInstall(type: NodeTask) {
-    doFirst {
-      println "react4xp build mode is set to '${project.ext.react4xp.BUILD_ENV}':\nOVERRIDING VANILLA npmInstall IN FAVOR OF node-safe-install (nsi) for retaining 'npm link' symlinks. For easy (POSIX) symlinking to npm-react4xp, stand in this projects root directory and run getlinks.sh with a relative link to a local npm-react4xp directory."
-    }
-
-    def buildSystemNsiPath = 'node_modules/@enonic/react4xp/node_modules/npm-safe-install/out/cli.js';
-    def buildSystemNsi = new File(buildSystemNsiPath);
-    if (buildSystemNsi.exists()) {
-      script = file(buildSystemNsiPath)
-    }
-
-    def localNsiPath = 'node_modules/npm-safe-install/out/cli.js';
-    def localNsi = new File(localNsiPath);
-    if (localNsi.exists()) {
-      script = file(localNsiPath)
-    }
-
-    doLast {
-      def marker = new File(markerName)
-      new File(marker.getParent()).mkdirs()
-      marker.text = """
-Marker file, indicating that the **nsiInstall** gradle task (yes, NSI - node-safe-install) has been run in this subproject - retaining any locally linked react4xp packages in node_module.
-"""
-    }
-  }
-  nsiInstall.inputs.files('package.json', 'package-lock.json', 'build.gradle')
-  nsiInstall.outputs.file('package-lock.json')
-  nsiInstall.outputs.file file(markerName)
-
-  npmInstall.enabled = false
-  npmInstall.dependsOn nsiInstall
 
 }

--- a/buildSrc/src/main/groovy/react4xp.gradle
+++ b/buildSrc/src/main/groovy/react4xp.gradle
@@ -1,0 +1,158 @@
+plugins {
+  id "com.github.node-gradle.node"
+}
+
+project.ext.react4xp = [
+    BUILD_ENV: 'production',
+    VERBOSE: 'false'
+]
+
+
+if (
+    project.hasProperty('dev')
+        || project.hasProperty('development')
+) {
+  project.ext.react4xp.BUILD_ENV='development';
+}
+
+
+// Used in ./npmInstall.gradle
+if (project.hasProperty("link") || project.hasProperty("linked") || project.ext.react4xp.BUILD_ENV == "development") {
+  project.ext.react4xp.NPMLINKED = true
+}
+
+
+if (gradle.startParameter.logLevel == LogLevel.INFO) {
+  project.ext.react4xp.VERBOSE = 'true';
+}
+
+
+task react4xpComponents(type: NpmTask) {
+  group 'React4xp'
+  description 'Compile the parent projects react components'
+  args = [
+      'explore', '@enonic/react4xp', '--',
+      'npm', 'run', 'webpack:components', '--',
+      '--env', 'DIR_PATH_ABSOLUTE_PROJECT=' + project.projectDir,
+      '--env', 'BUILD_ENV=' + project.ext.react4xp.BUILD_ENV,
+      '--env', 'VERBOSE=' + project.ext.react4xp.VERBOSE
+  ]
+  inputs.files fileTree(
+      dir: './',
+      include: [
+          'webpack.config.react4xp.js',
+          'src/main/resources/**/*.jsx',
+          'src/main/resources/**/*.tsx'
+      ]
+  )
+  outputs.dir 'build/resources/main'
+}
+jar.dependsOn += 'react4xpComponents'
+
+
+task react4xpExternals(type: NpmTask) {
+  group 'React4xp'
+  description 'Compile the externals (react and react-dom)'
+  args = [
+      'explore', '@enonic/react4xp', '--',
+      'npm', 'run', 'webpack:externals', '--',
+      '--env', 'DIR_PATH_ABSOLUTE_PROJECT=' + project.projectDir,
+      '--env', 'BUILD_ENV=' + project.ext.react4xp.BUILD_ENV,
+      '--env', 'VERBOSE=' + project.ext.react4xp.VERBOSE
+  ]
+  inputs.files fileTree(dir: './', include: 'react4xp.config.js')
+  outputs.dir 'build/resources/main/assets/react4xp'
+}
+jar.dependsOn += 'react4xpExternals'
+
+
+task react4xpNashornPolyfills(type: NpmTask) {
+  group 'React4xp'
+  description 'Run the imported react4xp webpack scripts that compile the components and externals (as well as nashorn polyfills if needed)'
+  args = [
+      'explore', '@enonic/react4xp', '--',
+      'npm', 'run', 'webpack:nashornPolyfills', '--',
+      '--env', 'DIR_PATH_ABSOLUTE_PROJECT=' + project.projectDir,
+      '--env', 'BUILD_ENV=' + project.ext.react4xp.BUILD_ENV,
+      '--env', 'VERBOSE=' + project.ext.react4xp.VERBOSE
+  ]
+  inputs.files fileTree(dir: 'src/main/resources', include: 'react4xpNashornPolyfills.es6')
+  outputs.dir 'build/resources/main/lib/enonic/react4xp'
+}
+jar.dependsOn += 'react4xpNashornPolyfills'
+
+
+StartParameter startParameter = project.gradle.startParameter;
+[
+    deploy,
+    build,
+    check,
+    test,
+    compileTestJava,
+    processTestResources,
+    assemble,
+    jar,
+    classes,
+    compileJava,
+    processResources,
+    npmInstall,
+    npmSetup,
+    nodeSetup,
+    clean
+].each { task ->
+
+  // This will make sure that various tasks are not run on when starting continuous build.
+  // However once a task is triggered by file change, it will still execute it's dependencies ;(
+  task.onlyIf { !startParameter.isContinuous() }
+
+  // This should skip a task even if it's "executed"
+  task.doFirst {
+    if (startParameter.isContinuous()) { throw new StopExecutionException() }
+  }
+
+}
+
+// Adds optional dev convenience: adjusts the regular 'npmInstall' gradle task with two improvements:
+//      - NSI allows npm-linked local development (https://www.npmjs.com/package/npm-safe-install)
+//      - faster gradle up-to-date check during build (only checks content of package.json and package-lock.json,
+//          and a marker file for whether node_module exists as a regular or NSI-linked version. Runs NSI if it's linked.
+//          Does not check the entire node_modules subtree).
+
+
+// These are not supplied from react4xp, they are just names used for buildtime housekeeping:
+def markerName = "node_modules/@enonic/react4xp/npmInstalled.marker"
+
+if (project.ext.react4xp.NPMLINKED == true) {
+  task nsiInstall(type: NodeTask) {
+    doFirst {
+      println "react4xp build mode is set to '${project.ext.react4xp.BUILD_ENV}':\nOVERRIDING VANILLA npmInstall IN FAVOR OF node-safe-install (nsi) for retaining 'npm link' symlinks. For easy (POSIX) symlinking to npm-react4xp, stand in this projects root directory and run getlinks.sh with a relative link to a local npm-react4xp directory."
+    }
+
+    def buildSystemNsiPath = 'node_modules/@enonic/react4xp/node_modules/npm-safe-install/out/cli.js';
+    def buildSystemNsi = new File(buildSystemNsiPath);
+    if (buildSystemNsi.exists()) {
+      script = file(buildSystemNsiPath)
+    }
+
+    def localNsiPath = 'node_modules/npm-safe-install/out/cli.js';
+    def localNsi = new File(localNsiPath);
+    if (localNsi.exists()) {
+      script = file(localNsiPath)
+    }
+
+    doLast {
+      def marker = new File(markerName)
+      new File(marker.getParent()).mkdirs()
+      marker.text = """
+Marker file, indicating that the **nsiInstall** gradle task (yes, NSI - node-safe-install) has been run in this subproject - retaining any locally linked react4xp packages in node_module.
+"""
+    }
+  }
+  nsiInstall.inputs.files('package.json', 'package-lock.json', 'build.gradle')
+  nsiInstall.outputs.file('package-lock.json')
+  nsiInstall.outputs.file file(markerName)
+
+  npmInstall.enabled = false
+  npmInstall.dependsOn nsiInstall
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Gradle Project settings
-projectName = react4xp
+projectName = starter-react4xp
 
 # XP App values
 appDisplayName = React4xp Example Starter


### PR DESCRIPTION
new react4xp.gradle is a join of react4xp.gradle and npmInstall.gradle files from npm, except from the messing with npmInstall input files in production (non-linked) mode.
It seems like marker file breaks correct flow of npmInstall

Other changes - to remove confusing comments/code from the starter.